### PR TITLE
Use batch/v1 for cronjob if k8s version is 1.21

### DIFF
--- a/charts/cronjob/Chart.lock
+++ b/charts/cronjob/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: lib-k8s-as-helm
-  repository: file://../lib-k8s-as-helm
-  version: 1.1.0
-digest: sha256:af89aadcdc81278d8787e1b5887a225e145d531b8cb4cd54ddc6b3412051448e
-generated: "2021-04-24T17:29:22.069848381-04:00"
+  repository: https://ameijer.github.io/k8s-as-helm
+  version: 1.3.0
+digest: sha256:3634daca791867d7ab4b27ddbe7e374ff2f5fd23cf1bf630fcdab1976b005513
+generated: "2022-12-14T14:15:03.673841-06:00"

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://ameijer.github.io/k8s-as-helm/icon.png
 dependencies:
 - name: lib-k8s-as-helm
   version: 1.3.0
-  repository: https://github.com/ameijer/k8s-as-helm/releases/download/lib-k8s-as-helm-1.3.0/lib-k8s-as-helm-1.3.0.tgz
+  repository: https://ameijer.github.io/k8s-as-helm
 maintainers:
   - name: ameijer
     url: https://github.com/ameijer

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -7,8 +7,8 @@ version: 1.0.1
 icon: https://ameijer.github.io/k8s-as-helm/icon.png
 dependencies:
 - name: lib-k8s-as-helm
-  version: 1.1.0
-  repository: file://../lib-k8s-as-helm
+  version: 1.3.0
+  repository: https://github.com/ameijer/k8s-as-helm/releases/download/lib-k8s-as-helm-1.3.0/lib-k8s-as-helm-1.3.0.tgz
 maintainers:
   - name: ameijer
     url: https://github.com/ameijer

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "v1.0.0"
+appVersion: "v1.0.1"
 home: https://github.com/ameijer/k8s-as-helm
 description: Helm Chart representing a single CronJob Kubernetes API object
 name: cronjob
-version: 1.0.0
+version: 1.0.1
 icon: https://ameijer.github.io/k8s-as-helm/icon.png
 dependencies:
 - name: lib-k8s-as-helm

--- a/charts/cronjob/templates/_helpers.tpl
+++ b/charts/cronjob/templates/_helpers.tpl
@@ -10,5 +10,8 @@ Setup a chart name
 Return the appropriate apiVersion for the object
 */}}
 {{- define "apiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- default "batch/v1" .Values.apiVersion -}}
+{{- else -}}
 {{- default "batch/v1beta1" .Values.apiVersion -}}
 {{- end -}}

--- a/charts/cronjob/templates/_helpers.tpl
+++ b/charts/cronjob/templates/_helpers.tpl
@@ -15,3 +15,4 @@ Return the appropriate apiVersion for the object
 {{- else -}}
 {{- default "batch/v1beta1" .Values.apiVersion -}}
 {{- end -}}
+{{- end -}}


### PR DESCRIPTION
v1beta1 API is deprecated in 1.21 and removed in 1.25.

Let me know if the release version should be something other than `1.0.1`