### PR TITLE
K8s helm build failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,23 +7,30 @@ on:
     paths:
       - 'charts/**'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.4.0
+          version: v3.14.4
       - name: Add Repo
-        run: helm repo add k8s-as-helm https://ameijer.github.io/k8s-as-helm
+        run: |
+          helm repo add k8s-as-helm https://ameijer.github.io/k8s-as-helm
+          helm repo update
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@39ca3e607fa86db3e4199276373c41a2422897f7
         env:
-          CR_TOKEN: '${{ secrets.CR_SECRET }}'
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix GitHub Actions release workflow by using `GITHUB_TOKEN` and setting `contents: write` permissions to resolve `401 Bad credentials`.

The build was failing because `chart-releaser-action` received `401 Bad credentials` due to `CR_TOKEN` being wired to an unset `secrets.CR_SECRET`. This change uses the built-in `GITHUB_TOKEN` and explicitly grants `contents: write` permissions. It also updates `checkout` and `setup-helm` action versions for modernization.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e6c9c25-3db9-406f-8866-0ad304ce106d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e6c9c25-3db9-406f-8866-0ad304ce106d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Helm chart release workflow authentication and modernizes the pipeline.
> 
> - Grants `permissions: contents: write` and switches `CR_TOKEN` to `${{ secrets.GITHUB_TOKEN }}` for `chart-releaser`
> - Upgrades `actions/checkout` to `v4` with `fetch-depth: 0`
> - Upgrades `azure/setup-helm` to `v3` and Helm to `v3.14.4`
> - Adds `helm repo update` after adding the repo
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8d8f2415796b478ba4d9adc5e0e70827426b14e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->