### PR TITLE
K8s object helm charts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,28 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct-lint.yaml --target-branch master
 
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.6.3
+
+      - name: Run helm-unittest (changed charts only)
+        run: |
+          set -euo pipefail
+          changed="$(ct list-changed --config .github/ct.yaml --target-branch master || true)"
+          if [[ -z "${changed}" ]]; then
+            echo "No chart changes detected"
+            exit 0
+          fi
+          for chart in ${changed}; do
+            if [[ "${chart}" == "lib-k8s-as-helm" ]]; then
+              continue
+            fi
+            if compgen -G "charts/${chart}/tests/*.yaml" > /dev/null; then
+              helm unittest "charts/${chart}"
+            else
+              echo "Skipping helm-unittest for charts/${chart} (no tests)"
+            fi
+          done
+
   kubeval-chart:
     runs-on: ubuntu-latest
     needs:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ API Object | Status | Link
 `RoleBinding` | :heavy_check_mark: | [rolebinding](https://github.com/ameijer/k8s-as-helm/tree/master/charts/rolebinding)
 `ServiceAccount` | :heavy_check_mark: | [serviceaccount](https://github.com/ameijer/k8s-as-helm/tree/master/charts/serviceaccount)
 `NetworkPolicy` | :heavy_check_mark: | [networkpolicy](https://github.com/ameijer/k8s-as-helm/tree/master/charts/networkpolicy)
+`ResourceQuota` | :heavy_check_mark: | [resourcequota](https://github.com/ameijer/k8s-as-helm/tree/master/charts/resourcequota)
+`LimitRange` | :heavy_check_mark: | [limitrange](https://github.com/ameijer/k8s-as-helm/tree/master/charts/limitrange)
 
 ## Contributing
 

--- a/charts/limitrange/Chart.yaml
+++ b/charts/limitrange/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+appVersion: "v1.0.0"
+home: https://github.com/ameijer/k8s-as-helm
+description: Helm Chart representing a single LimitRange Kubernetes API object
+name: limitrange
+version: 1.0.0
+icon: https://ameijer.github.io/k8s-as-helm/icon.png
+maintainers:
+  - name: ameijer
+    url: https://github.com/ameijer
+keywords:
+  - limitrange
+  - limits
+  - limit
+  - api
+  - primitives

--- a/charts/limitrange/NOTES.txt
+++ b/charts/limitrange/NOTES.txt
@@ -1,0 +1,2 @@
+
+The LimitRange Chart {{ .Release.Name }} has been installed into your cluster!

--- a/charts/limitrange/README.md
+++ b/charts/limitrange/README.md
@@ -1,0 +1,40 @@
+# LimitRange Chart
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/k8s-as-helm)](https://artifacthub.io/packages/search?repo=k8s-as-helm)
+
+## TL;DR;
+
+```console
+$ helm repo add k8s-as-helm https://ameijer.github.io/k8s-as-helm/
+$ helm install my-release k8s-as-helm/limitrange
+```
+
+## Introduction
+
+Helm charts are great! They are really configurable and let you build complicated software stacks in seconds. Tools like [Helmfile](https://github.com/roboll/helmfile) combine helm charts together to allow you to set up an environment consisting entirely of helm releases. 
+
+Let's say, though, you want to add additional code to a third party helm chart. You could make a new chart with your K8s API resource and the third party chart as a dependency, but that requires maintenance which might not be worth it if you only needed a single additional resource created. That's where k8s-as-helm charts come in. These charts wrap a single Kubernetes resource in a helm chart with all the key parameters exposed. 
+
+The limitrange chart deploys a single Kubernetes LimitRange object.
+
+## Installation 
+
+```console
+$ helm repo add k8s-as-helm https://ameijer.github.io/k8s-as-helm/
+$ helm install my-release k8s-as-helm/limitrange
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the limitrange chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`nameOverride` | override name of the chart component | .Release.Name
+`apiVersion` | api version of k8s object | `"v1"`
+`annotations` | annotations in yaml map format to be added to the object | `null`
+`labels` | labels to add to LimitRange object | `null`
+`limits` | (REQUIRED) spec.limits list | `[]`
+
+## Example Configuration
+
+For some examples of values used to configure this chart, see [the ci/example values for this chart](./ci/ci-values.yaml)

--- a/charts/limitrange/ci/ci-values.yaml
+++ b/charts/limitrange/ci/ci-values.yaml
@@ -1,0 +1,26 @@
+annotations:
+  example.com/annotation: "true"
+labels:
+  test: "true"
+  ci: "true"
+
+limits:
+  - type: Container
+    default:
+      cpu: 500m
+      memory: 512Mi
+    defaultRequest:
+      cpu: 200m
+      memory: 256Mi
+    max:
+      cpu: "1"
+      memory: 1Gi
+    min:
+      cpu: 100m
+      memory: 128Mi
+    maxLimitRequestRatio:
+      cpu: "10"
+  - type: Pod
+    max:
+      cpu: "2"
+      memory: 2Gi

--- a/charts/limitrange/templates/_helpers.tpl
+++ b/charts/limitrange/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Setup a chart name
+*/}}
+{{- define "limitrange.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for the object
+*/}}
+{{- define "apiVersion" -}}
+{{- default "v1" .Values.apiVersion -}}
+{{- end -}}

--- a/charts/limitrange/templates/limitrange.yaml
+++ b/charts/limitrange/templates/limitrange.yaml
@@ -1,0 +1,21 @@
+apiVersion: {{ template "apiVersion" . }}
+kind: LimitRange
+metadata:
+{{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4}}
+{{- end }}
+  labels:
+    app: {{ template "limitrange.name" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+  name: {{ template "limitrange.name" . }}
+spec:
+{{- if .Values.limits }}
+  limits:
+{{ toYaml .Values.limits | indent 4 }}
+{{- end }}

--- a/charts/limitrange/tests/limitrange_test.yaml
+++ b/charts/limitrange/tests/limitrange_test.yaml
@@ -1,0 +1,45 @@
+suite: limitrange
+templates:
+  - templates/limitrange.yaml
+tests:
+  - it: should render a LimitRange with limits
+    values:
+      - values/basic.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: LimitRange
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME
+      - equal:
+          path: spec.limits
+          value:
+            - type: Container
+              default:
+                cpu: 500m
+                memory: 512Mi
+
+  - it: should omit annotations when unset
+    set:
+      limits[0].type: Container
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should include annotations and labels when set
+    set:
+      annotations.test: "true"
+      labels.extra: "label"
+      limits[0].type: Container
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: "true"
+      - equal:
+          path: metadata.labels.extra
+          value: label

--- a/charts/limitrange/tests/values/basic.yaml
+++ b/charts/limitrange/tests/values/basic.yaml
@@ -1,0 +1,5 @@
+limits:
+  - type: Container
+    default:
+      cpu: 500m
+      memory: 512Mi

--- a/charts/limitrange/values.yaml
+++ b/charts/limitrange/values.yaml
@@ -1,0 +1,9 @@
+apiVersion: "v1"
+
+nameOverride: null
+
+annotations: null
+labels: null
+
+# (REQUIRED) LimitRange spec.limits list. See Kubernetes LimitRange documentation.
+limits: []

--- a/charts/resourcequota/Chart.yaml
+++ b/charts/resourcequota/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+appVersion: "v1.0.0"
+home: https://github.com/ameijer/k8s-as-helm
+description: Helm Chart representing a single ResourceQuota Kubernetes API object
+name: resourcequota
+version: 1.0.0
+icon: https://ameijer.github.io/k8s-as-helm/icon.png
+maintainers:
+  - name: ameijer
+    url: https://github.com/ameijer
+keywords:
+  - resourcequota
+  - quota
+  - resource
+  - api
+  - primitives

--- a/charts/resourcequota/NOTES.txt
+++ b/charts/resourcequota/NOTES.txt
@@ -1,0 +1,2 @@
+
+The ResourceQuota Chart {{ .Release.Name }} has been installed into your cluster!

--- a/charts/resourcequota/README.md
+++ b/charts/resourcequota/README.md
@@ -1,0 +1,42 @@
+# ResourceQuota Chart
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/k8s-as-helm)](https://artifacthub.io/packages/search?repo=k8s-as-helm)
+
+## TL;DR;
+
+```console
+$ helm repo add k8s-as-helm https://ameijer.github.io/k8s-as-helm/
+$ helm install my-release k8s-as-helm/resourcequota
+```
+
+## Introduction
+
+Helm charts are great! They are really configurable and let you build complicated software stacks in seconds. Tools like [Helmfile](https://github.com/roboll/helmfile) combine helm charts together to allow you to set up an environment consisting entirely of helm releases. 
+
+Let's say, though, you want to add additional code to a third party helm chart. You could make a new chart with your K8s API resource and the third party chart as a dependency, but that requires maintenance which might not be worth it if you only needed a single additional resource created. That's where k8s-as-helm charts come in. These charts wrap a single Kubernetes resource in a helm chart with all the key parameters exposed. 
+
+The resourcequota chart deploys a single Kubernetes ResourceQuota object.
+
+## Installation 
+
+```console
+$ helm repo add k8s-as-helm https://ameijer.github.io/k8s-as-helm/
+$ helm install my-release k8s-as-helm/resourcequota
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the resourcequota chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`nameOverride` | override name of the chart component | .Release.Name
+`apiVersion` | api version of k8s object | `"v1"`
+`annotations` | annotations in yaml map format to be added to the object | `null`
+`labels` | labels to add to ResourceQuota object | `null`
+`hard` | (REQUIRED) map of resource quota hard limits | `null`
+`scopes` | optional list of scopes | `[]`
+`scopeSelector` | optional scope selector for priority class, etc. | `null`
+
+## Example Configuration
+
+For some examples of values used to configure this chart, see [the ci/example values for this chart](./ci/ci-values.yaml)

--- a/charts/resourcequota/ci/ci-values.yaml
+++ b/charts/resourcequota/ci/ci-values.yaml
@@ -1,0 +1,22 @@
+annotations:
+  example.com/annotation: "true"
+labels:
+  test: "true"
+  ci: "true"
+
+hard:
+  pods: "10"
+  requests.cpu: "4"
+  requests.memory: 8Gi
+  limits.cpu: "8"
+  limits.memory: 16Gi
+
+scopes:
+  - NotTerminating
+
+scopeSelector:
+  matchExpressions:
+    - scopeName: PriorityClass
+      operator: In
+      values:
+        - high

--- a/charts/resourcequota/templates/_helpers.tpl
+++ b/charts/resourcequota/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Setup a chart name
+*/}}
+{{- define "resourcequota.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for the object
+*/}}
+{{- define "apiVersion" -}}
+{{- default "v1" .Values.apiVersion -}}
+{{- end -}}

--- a/charts/resourcequota/templates/resourcequota.yaml
+++ b/charts/resourcequota/templates/resourcequota.yaml
@@ -1,0 +1,32 @@
+apiVersion: {{ template "apiVersion" . }}
+kind: ResourceQuota
+metadata:
+{{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4}}
+{{- end }}
+  labels:
+    app: {{ template "resourcequota.name" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+  name: {{ template "resourcequota.name" . }}
+spec:
+{{- if .Values.hard }}
+  hard:
+{{ toYaml .Values.hard | indent 4 }}
+{{- end }}
+{{- if .Values.scopes }}
+  scopes:
+{{ toYaml .Values.scopes | indent 4 }}
+{{- end }}
+{{- if .Values.scopeSelector }}
+  scopeSelector:
+{{- if .Values.scopeSelector.matchExpressions }}
+    matchExpressions:
+{{ toYaml .Values.scopeSelector.matchExpressions | indent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/resourcequota/tests/resourcequota_test.yaml
+++ b/charts/resourcequota/tests/resourcequota_test.yaml
@@ -1,0 +1,52 @@
+suite: resourcequota
+templates:
+  - templates/resourcequota.yaml
+tests:
+  - it: should render a ResourceQuota with defaults
+    set:
+      hard.pods: "10"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ResourceQuota
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME
+      - exists:
+          path: spec.hard.pods
+
+  - it: should omit optional metadata when unset
+    set:
+      hard.pods: "10"
+    asserts:
+      - notExists:
+          path: metadata.annotations
+      - notExists:
+          path: spec.scopes
+      - notExists:
+          path: spec.scopeSelector
+
+  - it: should include labels, annotations, scopes, and scopeSelector when set
+    values:
+      - values/full.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: "true"
+      - equal:
+          path: metadata.labels.extra
+          value: label
+      - equal:
+          path: spec.scopes[0]
+          value: NotTerminating
+      - equal:
+          path: spec.scopeSelector.matchExpressions
+          value:
+            - scopeName: PriorityClass
+              operator: In
+              values:
+                - high

--- a/charts/resourcequota/tests/values/full.yaml
+++ b/charts/resourcequota/tests/values/full.yaml
@@ -1,0 +1,17 @@
+annotations:
+  test: "true"
+labels:
+  extra: label
+
+hard:
+  pods: "10"
+
+scopes:
+  - NotTerminating
+
+scopeSelector:
+  matchExpressions:
+    - scopeName: PriorityClass
+      operator: In
+      values:
+        - high

--- a/charts/resourcequota/values.yaml
+++ b/charts/resourcequota/values.yaml
@@ -1,0 +1,15 @@
+apiVersion: "v1"
+
+nameOverride: null
+
+annotations: null
+labels: null
+
+# (REQUIRED) ResourceQuota hard limits. See Kubernetes ResourceQuota documentation.
+hard: null
+
+# Optional scopes (e.g. NotTerminating, BestEffort, NotBestEffort, Terminating).
+scopes: []
+
+# Optional scopeSelector. See Kubernetes ResourceQuota documentation.
+scopeSelector: null


### PR DESCRIPTION
Adds new Helm charts for `ResourceQuota` and `LimitRange` Kubernetes objects, including comprehensive unit tests, CI integration, and documentation, as requested in issue #44.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7f39e33-8030-4aa3-b2a4-ba798fcfca0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7f39e33-8030-4aa3-b2a4-ba798fcfca0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces two new Kubernetes primitive charts and CI unit testing.
> 
> - Adds `charts/resourcequota` and `charts/limitrange` with `templates`, `_helpers.tpl`, `values.yaml`, `README.md`, and `NOTES.txt`
> - Provides example configs under `ci/ci-values.yaml` and helm-unittest suites in `tests/*.yaml`
> - Updates CI workflow `.github/workflows/ci.yaml` to install the `helm-unittest` plugin and run tests for changed charts (skips `lib-k8s-as-helm`)
> - Updates repo `README.md` to mark and link `ResourceQuota` and `LimitRange` as supported
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2774d24ea7b52afcf54c07bf5729b608fec069b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->